### PR TITLE
fix(nix): add missing restart triggers

### DIFF
--- a/services/newt.nix
+++ b/services/newt.nix
@@ -20,4 +20,8 @@
       config.sops.templates."newt-env".path
     ];
   };
+
+  systemd.services."podman-newt".restartTriggers = [
+    config.sops.templates."newt-env".file
+  ];
 }

--- a/services/ntfy.nix
+++ b/services/ntfy.nix
@@ -39,4 +39,8 @@
       "--cap-add=NET_BIND_SERVICE"
     ];
   };
+
+  systemd.services."podman-ntfy".restartTriggers = [
+    config.sops.templates."ntfy-env".file
+  ];
 }

--- a/services/papra.nix
+++ b/services/papra.nix
@@ -28,4 +28,8 @@
       config.sops.templates."papra-env".path
     ];
   };
+
+  systemd.services."podman-papra".restartTriggers = [
+    config.sops.templates."papra-env".file
+  ];
 }


### PR DESCRIPTION
environment files are unmanaged, so they need an explicit watch policy